### PR TITLE
[Fix] Fix lambda node failures

### DIFF
--- a/sygra/core/graph/backend_factory.py
+++ b/sygra/core/graph/backend_factory.py
@@ -10,13 +10,12 @@ class BackendFactory(ABC):
     """
 
     @abstractmethod
-    def create_lambda_runnable(self, function_to_execute, node_config):
+    def create_lambda_runnable(self, exec_wrapper):
         """
         Abstract method to create a Lambda runnable.
 
         Args:
-            function_to_execute: Python function to execute, if it is a class it should be callable(__call__)
-            node_config:node config dictionary
+            exec_wrapper: Async function to execute
 
         Returns:
             Any: backend specific runnable object like Runnable for backend=Langgraph

--- a/sygra/core/graph/langgraph/langgraph_factory.py
+++ b/sygra/core/graph/langgraph/langgraph_factory.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Any
 
 from langchain_core.messages import BaseMessage
@@ -18,18 +17,17 @@ class LangGraphFactory(BackendFactory):
     A factory class to convert Nodes into Runnable objects which LangGraph framework can execute.
     """
 
-    def create_lambda_runnable(self, function_to_execute, node_config):
+    def create_lambda_runnable(self, exec_wrapper):
         """
         Abstract method to create a Lambda runnable.
 
         Args:
-            function_to_execute: Python function to execute, if it is a class it should be callable(__call__)
-            node_config:node config dictionary
+            exec_wrapper: Async function to execute
 
         Returns:
             Any: backend specific runnable object like Runnable for backend=Langgraph
         """
-        return RunnableLambda(partial(function_to_execute, node_config))
+        return RunnableLambda(lambda x: x, afunc=exec_wrapper)
 
     def create_llm_runnable(self, exec_wrapper):
         """

--- a/sygra/core/graph/nodes/lambda_node.py
+++ b/sygra/core/graph/nodes/lambda_node.py
@@ -38,7 +38,7 @@ class LambdaNode(BaseNode):
         success = True
 
         try:
-            result: dict[str, Any] = self.func_to_execute(state)
+            result: dict[str, Any] = self.func_to_execute(self.node_config, state)
             return result
         except Exception:
             success = False
@@ -53,7 +53,7 @@ class LambdaNode(BaseNode):
         Returns:
              Any: platform specific runnable object like Runnable in LangGraph.
         """
-        return utils.backend_factory.create_lambda_runnable(self._exec_wrapper, self.node_config)
+        return utils.backend_factory.create_lambda_runnable(self._exec_wrapper)
 
     def validate_node(self):
         """

--- a/sygra/core/models/lite_llm/vllm_model.py
+++ b/sygra/core/models/lite_llm/vllm_model.py
@@ -22,7 +22,7 @@ class CustomVLLM(LiteLLMBase):
         utils.validate_required_keys(["url", "auth_token"], model_config, "model")
         self.model_config = model_config
         self.auth_token = str(model_config.get("auth_token")).replace("Bearer ", "")
-        self.model_serving_name = model_config.get("model_serving_name", self.name())
+        self.model_name = model_config.get("model_serving_name", self.name())
 
     def _validate_completions_api_model_support(self) -> None:
         logger.info(f"Model {self.name()} supports completion API.")

--- a/tests/core/models/lite_llm/test_litellm_vllm.py
+++ b/tests/core/models/lite_llm/test_litellm_vllm.py
@@ -56,11 +56,11 @@ class TestLiteLLMVLLM(unittest.TestCase):
         self.assertEqual(model.generation_params, self.base_config["parameters"])
         self.assertEqual(model.name(), "vllm_model")
         self.assertEqual(model.auth_token, "test_token_123")
-        self.assertEqual(model.model_serving_name, "vllm_model")
+        self.assertEqual(model.model_name, "vllm_model")
 
     def test_init_with_custom_serving_name(self):
         model = LiteLLMVLLM(self.serving_name_config)
-        self.assertEqual(model.model_serving_name, "custom_serving_name")
+        self.assertEqual(model.model_name, "custom_serving_name")
 
     @patch("sygra.core.models.lite_llm.vllm_model.logger")
     def test_init_with_completions_api(self, mock_logger):


### PR DESCRIPTION
## Summary (Bug Fix)
This PR fixes multiple issues in the LambdaNode execution path and LangGraph backend integration:

- **LambdaNode was not passing `node_config`** to `func_to_execute`, causing unexpected runtime errors.
- **vLLM model config attribute mismatch** (`model_serving_name` vs `model_name`) caused failing tests and incorrect initialization.  
  This PR standardizes it and updates tests accordingly.

## 🔧 Impacted Components
- 🧠 `LambdaNode._exec_wrapper` — now correctly calls `func_to_execute(node_config, state)`
- 🔌 `BackendFactory` & `LangGraphFactory` — fixed API mismatch, now accept `exec_wrapper` only
- 🚀 `LiteLLMVLLM` — fixes incorrect attribute name leading to wrong model initialization & test failures

## 🧪 How to Test
1. Run unit tests:
   ```bash
   make test-verbose
   ```
2. Create a simple LambdaNode and run:
- Ensure the function receives both node_config and state
- Validate LangGraph runnable executes without errors

3. Initialize LiteLLMVLLM with and without model_serving_name:
- Confirm model_name is populated correctly
- Updated tests in test_litellm_vllm.py should pass

## 📸 Screenshots
N/A

## ✅ Checklist
- [x] Lint fixes and unit testing done
- [x] End to end task testing
- [ ] Documentation updated

## Notes
This PR unblocks LambdaNode execution and standardizes backend runnable handling.
No external API changes expected for end users.


